### PR TITLE
Stacking of diacritics: accent, grave, macron, and tilde (uni0300, 301, 303, 304)

### DIFF
--- a/sources/LibertinusSerif-Regular.sfd
+++ b/sources/LibertinusSerif-Regular.sfd
@@ -15241,7 +15241,7 @@ Encoding: 769 769 670
 Width: 0
 GlyphClass: 4
 Flags: MW
-AnchorPoint: "SekAccPos" -191 692 mark 0
+AnchorPoint: "SekAccPos" -191 682 mark 0
 AnchorPoint: "SekAccPos" -191 914 basemark 0
 AnchorPoint: "above" -191 682 mark 0
 LayerCount: 2

--- a/sources/LibertinusSerif-Regular.sfd
+++ b/sources/LibertinusSerif-Regular.sfd
@@ -15218,6 +15218,8 @@ Encoding: 768 768 669
 Width: 0
 GlyphClass: 4
 Flags: MW
+AnchorPoint: "SekAccPos" -142 870 basemark 0
+AnchorPoint: "SekAccPos" -142 683 mark 0
 AnchorPoint: "above" -142 683 mark 0
 LayerCount: 2
 Fore
@@ -15239,8 +15241,8 @@ Encoding: 769 769 670
 Width: 0
 GlyphClass: 4
 Flags: MW
-AnchorPoint: "SekAccPos" -192 692 mark 0
-AnchorPoint: "SekAccPos" -196 914 basemark 0
+AnchorPoint: "SekAccPos" -191 692 mark 0
+AnchorPoint: "SekAccPos" -191 914 basemark 0
 AnchorPoint: "above" -191 682 mark 0
 LayerCount: 2
 Fore
@@ -15283,6 +15285,7 @@ Encoding: 771 771 672
 Width: 0
 GlyphClass: 4
 Flags: MW
+AnchorPoint: "SekAccPos" -138 697 mark 0
 AnchorPoint: "SekAccPos" -138 874 basemark 0
 AnchorPoint: "above" -139 697 mark 0
 LayerCount: 2
@@ -32939,8 +32942,8 @@ Encoding: 772 772 1419
 Width: 0
 GlyphClass: 4
 Flags: MW
-AnchorPoint: "SekAccPos" -206 653 mark 0
-AnchorPoint: "SekAccPos" -210 824 basemark 0
+AnchorPoint: "SekAccPos" -209 645 mark 0
+AnchorPoint: "SekAccPos" -209 824 basemark 0
 AnchorPoint: "above" -209 645 mark 0
 LayerCount: 2
 Fore
@@ -74578,7 +74581,7 @@ Refer: 29 70 N -1 0 0 -1 485 647 3
 EndChar
 
 StartChar: uniA78A
-Encoding: 42890 42890 2676
+Encoding: 42890 42890 2671
 Width: 338
 Flags: W
 LayerCount: 2


### PR DESCRIPTION
Sometimes, one wants to stack diacritics, such as a grave above a macron or tilde, etc. The anchor point `SekAccPos` is already in place for some combining characters. However, it had missing/oddly placed bases and/or marks for the accent, grave, macron, and tilde. I added/moved the respective anchors.