### PR TITLE
modifier letters raised excl, raised arrows, saltillos

### DIFF
--- a/sources/LibertinusSerif-Bold.sfd
+++ b/sources/LibertinusSerif-Bold.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.0
+SplineFontDB: 3.2
 FontName: LibertinusSerif-Bold
 FullName: Libertinus Serif Bold
 FamilyName: Libertinus Serif
@@ -21,6 +21,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1156455862
+ModificationTime: 1579098602
 PfmFamily: 17
 TTFWeight: 700
 TTFWidth: 5
@@ -299,7 +300,7 @@ Grid
  -113 550 l 1025
 EndSplineSet
 AnchorClass2: "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR" "right" "'mark' Right"
-BeginChars: 1114410 2435
+BeginChars: 1114410 2440
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -61575,6 +61576,67 @@ SplineSet
  39 266 l 1
  39 323 l 1
  320 323 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniA71C
+Encoding: 42780 42780 2435
+Width: 161
+Flags: W
+LayerCount: 2
+Fore
+Refer: 1170 8595 N 0.384518 0 0 0.379323 -13.3223 433.313 2
+EndChar
+
+StartChar: uniA71B
+Encoding: 42779 42779 2436
+Width: 161
+Flags: W
+LayerCount: 2
+Fore
+Refer: 1170 8595 N 0.384518 0 0 -0.379323 -13.3223 651.424 2
+EndChar
+
+StartChar: uniA71D
+Encoding: 42781 42781 2437
+Width: 161
+Flags: W
+LayerCount: 2
+Fore
+Refer: 0 33 N 0.580479 0 0 0.569945 3.29623 355.699 2
+EndChar
+
+StartChar: uniA78B
+Encoding: 42891 42891 2438
+Width: 215
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+98 411 m 1
+ 83 415 l 1
+ 83 415 51 638 51 644 c 0
+ 51 667 73 698 116 698 c 0
+ 158 698 161 679 161 661 c 0
+ 161 646 124 417 124 417 c 1
+ 98 411 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniA78C
+Encoding: 42892 42892 2439
+Width: 215
+Flags: HWO
+LayerCount: 2
+Fore
+SplineSet
+98 348.5 m 1
+ 83 352.5 l 1
+ 83 352.5 51 585 51 591 c 0
+ 51 614 73 645 116 645 c 0
+ 158 645 161 626 161 608 c 0
+ 161 593 124 354.5 124 354.5 c 1
+ 98 348.5 l 1
 EndSplineSet
 EndChar
 EndChars

--- a/sources/LibertinusSerif-BoldItalic.sfd
+++ b/sources/LibertinusSerif-BoldItalic.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.0
+SplineFontDB: 3.2
 FontName: LibertinusSerif-BoldItalic
 FullName: Libertinus Serif Bold Italic
 FamilyName: Libertinus Serif
@@ -21,6 +21,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1155510122
+ModificationTime: 1579098638
 PfmFamily: 17
 TTFWeight: 700
 TTFWidth: 5
@@ -288,7 +289,7 @@ Grid
  -463 550 l 1025
 EndSplineSet
 AnchorClass2: "top_punkt" "'mark' Top Punkt" "right" "'mark' Right" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR"
-BeginChars: 1114407 1889
+BeginChars: 1114407 1894
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -56299,6 +56300,67 @@ SplineSet
  112.099609375 266 l 1
  124.299804688 323 l 1
  374 323 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniA71D
+Encoding: 42781 42781 1889
+Width: 161
+Flags: HW
+LayerCount: 2
+Fore
+Refer: 0 33 N 0.580479 0 0 0.569945 84.908 355.699 2
+EndChar
+
+StartChar: uniA71C
+Encoding: 42780 42780 1890
+Width: 161
+Flags: HW
+LayerCount: 2
+Fore
+Refer: 822 8595 N 0.441624 0 0 0.371358 71.127 438.884 2
+EndChar
+
+StartChar: uniA71B
+Encoding: 42779 42779 1891
+Width: 161
+Flags: HW
+LayerCount: 2
+Fore
+Refer: 1890 42780 N -1 0 -0 -1 393.324 1093 2
+EndChar
+
+StartChar: uniA78B
+Encoding: 42891 42891 1892
+Width: 215
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+126.6 411 m 1
+ 113.4 415 l 1
+ 113.4 415 130.453125 638 131.75390625 644 c 4
+ 136.653320312 667 163.953125 698 204.353515625 698 c 4
+ 243.853515625 698 242.553710938 679 238.75390625 661 c 4
+ 235.553710938 646 152.3 417 152.3 417 c 1
+ 126.6 411 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniA78C
+Encoding: 42892 42892 1893
+Width: 215
+Flags: HWO
+LayerCount: 2
+Fore
+SplineSet
+115.969726562 357.900390625 m 1
+ 102.76953125 361.900390625 l 1
+ 102.76953125 361.900390625 119.420787612 584.99553369 120.7 591 c 0
+ 125.6 614 152.9 645 193.3 645 c 0
+ 232.8 645 231.538267477 625.9918788 227.7 608 c 0
+ 224.5 593 141.669921875 363.900390625 141.669921875 363.900390625 c 1
+ 115.969726562 357.900390625 l 1
 EndSplineSet
 EndChar
 EndChars

--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -4361,7 +4361,7 @@ GlyphClass: 2
 Flags: MW
 LayerCount: 2
 Fore
-Refer: 1410 772 N 1 0 0 1 443 32 2
+Refer: 1410 772 N 1 0 0 1 443 1 2
 Refer: 289 103 N 1 0 0 1 0 0 2
 EndChar
 

--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.0
+SplineFontDB: 3.2
 FontName: LibertinusSerif-Italic
 FullName: Libertinus Serif Italic
 FamilyName: Libertinus Serif
@@ -21,6 +21,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1155510122
+ModificationTime: 1579098562
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
@@ -307,7 +308,7 @@ Grid
  -463 550 l 1025
 EndSplineSet
 AnchorClass2: "right" "'mark' Right" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR"
-BeginChars: 65826 2381
+BeginChars: 65826 2386
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -72963,6 +72964,67 @@ SplineSet
  93 269 l 1
  102 318 l 1
  348 318 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniA71D
+Encoding: 42781 42781 2381
+Width: 161
+Flags: W
+LayerCount: 2
+Fore
+Refer: 0 33 N 0.548341 0 0 0.593658 93.1941 362.218 2
+EndChar
+
+StartChar: uniA71C
+Encoding: 42780 42780 2382
+Width: 161
+Flags: HW
+LayerCount: 2
+Fore
+Refer: 1171 8595 S 0.441624 0 0 0.371358 71.127 438.884 2
+EndChar
+
+StartChar: uniA71B
+Encoding: 42779 42779 2383
+Width: 161
+Flags: HW
+LayerCount: 2
+Fore
+Refer: 2382 42780 S -1 0 -0 -1 392.963 1091.3 2
+EndChar
+
+StartChar: uniA78B
+Encoding: 42891 42891 2384
+Width: 190
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+154 426 m 1
+ 154 426 167.479492188 639 169.479492188 648 c 4
+ 172.479492188 670 199.479492188 698 229.479492188 698 c 4
+ 251.479492188 698 258.479492188 685 258.479492188 672 c 4
+ 258.479492188 669 258.479492188 667 258.479492188 665 c 4
+ 255.479492188 649 182 430 182 430 c 1
+ 154 426 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniA78C
+Encoding: 42892 42892 2385
+Width: 190
+Flags: HWO
+LayerCount: 2
+Fore
+SplineSet
+138.689453125 358.299804688 m 1
+ 138.689453125 358.299804688 156.754317802 584.864997216 158 594 c 0
+ 161 616 188 644 218 644 c 0
+ 240 644 247 631 247 618 c 0
+ 247 615 247.36857707 612.965744374 247 611 c 0
+ 244 595 166.689453125 362.299804688 166.689453125 362.299804688 c 1
+ 138.689453125 358.299804688 l 1
 EndSplineSet
 EndChar
 EndChars

--- a/sources/LibertinusSerif-Regular.sfd
+++ b/sources/LibertinusSerif-Regular.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.0
+SplineFontDB: 3.2
 FontName: LibertinusSerif-Regular
 FullName: Libertinus Serif Regular
 FamilyName: Libertinus Serif
@@ -21,6 +21,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1156455862
+ModificationTime: 1579099491
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
@@ -303,7 +304,7 @@ Grid
  -113 550 l 1025
 EndSplineSet
 AnchorClass2: "aboveMark" "'mkmk' Mark to Mark-1" "right" "'mark' Right" "komb_OR" "'mark' Komb OR" "above" "'mark' Above" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle"
-BeginChars: 1114450 2672
+BeginChars: 1114450 2676
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -74601,6 +74602,56 @@ SplineSet
  282 193 l 2
  292 193 296 184 296 176 c 0
  296 166 282 143 269 143 c 2
+EndSplineSet
+EndChar
+
+StartChar: uniA71C
+Encoding: 42780 42780 2672
+Width: 161
+Flags: HWO
+LayerCount: 2
+Fore
+Refer: 1170 8595 S 0.441624 0 0 0.371358 -26.7563 438.884 2
+EndChar
+
+StartChar: uniA71B
+Encoding: 42779 42779 2673
+Width: 161
+Flags: HW
+LayerCount: 2
+Fore
+Refer: 2672 42780 S 1 0 0 -1 0 1093 2
+EndChar
+
+StartChar: uniA78C
+Encoding: 42892 42892 2674
+Width: 190
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+76 357.299804688 m 1
+ 76 357.299804688 53 585 53 594 c 0
+ 53 616 74 644 104 644 c 0
+ 130 644 139 627 139 611 c 0
+ 139 595 103 361.299804688 103 361.299804688 c 1
+ 76 357.299804688 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniA78B
+Encoding: 42891 42891 2675
+Width: 190
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+79 426 m 1
+ 79 426 51 639 51 648 c 0
+ 51 670 72 698 102 698 c 0
+ 128 698 137 681 137 665 c 0
+ 137 649 106 430 106 430 c 1
+ 79 426 l 1
 EndSplineSet
 EndChar
 EndChars

--- a/sources/LibertinusSerif-Semibold.sfd
+++ b/sources/LibertinusSerif-Semibold.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.0
+SplineFontDB: 3.2
 FontName: LibertinusSerif-Semibold
 FullName: Libertinus Serif Semibold
 FamilyName: Libertinus Serif Semibold
@@ -21,6 +21,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1156455862
+ModificationTime: 1579098433
 PfmFamily: 17
 TTFWeight: 600
 TTFWidth: 5
@@ -235,7 +236,7 @@ Grid
  766 430 l 25
 EndSplineSet
 AnchorClass2: "acute"""  "above" "'mark' Mark Positioning lookup 4" "top_punkt" "'mark' Mark Positioning lookup 4" "below" "'mark' Mark Positioning lookup 3" "cedilla" "'mark' Mark Positioning lookup 2" "ogonek" "'mark' Mark Positioning lookup 1" "middle" "'mark' Mark Positioning in Hebrew lookup 0"
-BeginChars: 65810 2348
+BeginChars: 65810 2353
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -61004,6 +61005,67 @@ SplineSet
  39 266 l 1
  39 323 l 1
  320 323 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniA71C
+Encoding: 42780 42780 2348
+Width: 161
+Flags: W
+LayerCount: 2
+Fore
+Refer: 1170 8595 N 0.441624 0 0 0.371358 -26.7563 438.884 2
+EndChar
+
+StartChar: uniA71B
+Encoding: 42779 42779 2349
+Width: 161
+Flags: W
+LayerCount: 2
+Fore
+Refer: 2348 42780 N 1 0 0 -1 0 1091.3 2
+EndChar
+
+StartChar: uniA71D
+Encoding: 42781 42781 2350
+Width: 161
+Flags: W
+LayerCount: 2
+Fore
+Refer: 0 33 N 0.541667 0 0 0.553443 14.4167 363.834 2
+EndChar
+
+StartChar: uniA78C
+Encoding: 42892 42892 2351
+Width: 215
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+98 352.299804688 m 1
+ 83 356.299804688 l 1
+ 83 356.299804688 51 585 51 591 c 0
+ 51 614 73 645 116 645 c 0
+ 158 645 161 626 161 608 c 0
+ 161 593 124 358.299804688 124 358.299804688 c 1
+ 98 352.299804688 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniA78B
+Encoding: 42891 42891 2352
+Width: 215
+Flags: HWO
+LayerCount: 2
+Fore
+SplineSet
+98 421 m 1
+ 83 425 l 1
+ 83 425 51 638 51 644 c 0
+ 51 667 73 698 116 698 c 0
+ 158 698 161 679 161 661 c 0
+ 161 646 124 427 124 427 c 1
+ 98 421 l 1
 EndSplineSet
 EndChar
 EndChars

--- a/sources/LibertinusSerif-SemiboldItalic.sfd
+++ b/sources/LibertinusSerif-SemiboldItalic.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.0
+SplineFontDB: 3.2
 FontName: LibertinusSerif-SemiboldItalic
 FullName: Libertinus Serif Semibold Italic
 FamilyName: Libertinus Serif Semibold
@@ -21,6 +21,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1162161130
+ModificationTime: 1579099373
 PfmFamily: 17
 TTFWeight: 600
 TTFWidth: 5
@@ -209,7 +210,7 @@ Grid
  766 430 l 25
 EndSplineSet
 AnchorClass2: "top_punkt" "'mark' Top Punkt" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR" "right" "'mark' Right"
-BeginChars: 1114414 2360
+BeginChars: 1114414 2365
 
 StartChar: space
 Encoding: 32 32 0
@@ -72692,6 +72693,69 @@ SplineSet
  104 323 l 1
  405.666992188 323 l 1
 EndSplineSet
+EndChar
+
+StartChar: uniA71B
+Encoding: 42779 42779 2360
+Width: 161
+Flags: HW
+LayerCount: 2
+Fore
+Refer: 2363 42780 N -1 0 -0 -1 392.173 1091.3 2
+EndChar
+
+StartChar: uniA78B
+Encoding: 42891 42891 2361
+Width: 232
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+197 421 m 1
+ 182 425 l 1
+ 182 425 198.779296875 638 198.779296875 644 c 1
+ 203.779296875 667 232.779296875 698 275.779296875 698 c 0
+ 306.779296875 698 314.779296875 687 314.779296875 674 c 0
+ 314.779296875 670 313.779296875 665 312.779296875 661 c 0
+ 309.779296875 646 232 427 232 427 c 1
+ 197 421 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniA78C
+Encoding: 42892 42892 2362
+Width: 232
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+186.830078125 368 m 1
+ 171.830078125 372 l 1
+ 171.830078125 372 188 585 188 591 c 1
+ 193 614 222 645 265 645 c 0
+ 296 645 304 634 304 621 c 0
+ 304 617 302.80860754 612.0430377 302 608 c 0
+ 299 593 221.830078125 374 221.830078125 374 c 1
+ 186.830078125 368 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniA71C
+Encoding: 42780 42780 2363
+Width: 161
+Flags: HW
+LayerCount: 2
+Fore
+Refer: 1604 8595 N 0.441624 0 0 0.371358 71.127 438.884 2
+EndChar
+
+StartChar: uniA71D
+Encoding: 42781 42781 2364
+Width: 161
+Flags: HW
+LayerCount: 2
+Fore
+Refer: 1 33 N 0.570116 0 0 0.576705 85.4205 373.106 2
 EndChar
 EndChars
 EndSplineFont


### PR DESCRIPTION
This commit adds five symbols, important to users in linguistics, to the serif types:

- `uniA71B`, raised exclamation mark: ꜝ
- `uniA71C`, raised upward arrow: ꜛ
- `uniA71D`, raised downward arrow: ꜜ
- `uniA78B`, capital Saltillo: Ꞌ
- `uniA78C`, small Saltillo: ꞌ 

I did not amend with `make normalize`, because that would have altered glyphs I did not touch in my edit (e.g. `ograve` and some others). My FontForge version is 20190801.