### PR TITLE
Add `afdko` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+afdko==3.2.1
 fonttools[ufo,lxml]==4.6.0
 pcpp==1.21
 psautohint==2.0.1


### PR DESCRIPTION
As suggested [here](https://github.com/alif-type/libertinus/pull/307#issuecomment-605550356), all Python modules needed for this package should be listed in the `requirements.txt` file. `make` only works for me if `afdko` is included explicitly; otherwise, it fails with the following error:

```
(libertinus-env) ❯ make
      BUILD  LibertinusSans-Regular
       HINT  LibertinusSans-Regular
       SUBR  LibertinusSans-Regular
make: *** [build/LibertinusSans-Regular.subr.otf] Error 127
```