### PR TITLE
Downgrade skia-pathops dependency to simplify setup process

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ afdko==3.2.1
 fonttools[ufo,lxml]==4.6.0
 pcpp==1.21
 psautohint==2.0.1
-skia-pathops==0.4.0
+skia-pathops==0.3.0
 ufo2ft==2.13.0
 ufoLib2==0.6.2
 git+git://github.com/alif-type/sfdLib.git@v1.0.0#egg=sfdLib


### PR DESCRIPTION
Since v0.3.0, `skia-pathops` started building `libskia` from source, and this causes issues in some systems because it needs Python2, which is EOL.

This change downgrades the `skia-pathops` dependency to the version before v0.3.0, until a new release is made that doesn't depend on Python2.

Fixes #314.